### PR TITLE
Add Keycloak service and configure Bahmni auth

### DIFF
--- a/apps/keycloak/README.md
+++ b/apps/keycloak/README.md
@@ -1,0 +1,20 @@
+# Keycloak setup
+
+This directory contains files related to the Keycloak identity provider used by Bahmni.
+
+## Initial setup
+1. Start Keycloak with docker compose:
+   ```bash
+   docker compose up -d keycloak
+   ```
+2. Sign in at [http://localhost:8081](http://localhost:8081) with the admin credentials from `.env` (`KEYCLOAK_ADMIN_USER`/`KEYCLOAK_ADMIN_PASSWORD`).
+3. Create a realm matching `KEYCLOAK_REALM`.
+4. Create clients for the Bahmni services using the IDs defined in `.env`:
+   - `KEYCLOAK_CLIENT_OPENMRS`
+   - `KEYCLOAK_CLIENT_ODOO`
+   - `KEYCLOAK_CLIENT_OPENELIS`
+   - `KEYCLOAK_CLIENT_BAHMNI_WEB`
+5. Configure redirect URIs and grant types for each client as required.
+6. Restart the Bahmni containers so they can authenticate against Keycloak.
+
+Realm export files placed in this directory will be mounted into the Keycloak container for import on startup.

--- a/bahmni-standard/.env
+++ b/bahmni-standard/.env
@@ -6,6 +6,18 @@ TZ=UTC
 
 LOKI_URL=http://localhost:3100/loki/api/v1/push
 
+# Keycloak Environment Variables
+KEYCLOAK_IMAGE_TAG=21.0.1
+KEYCLOAK_URL=http://keycloak:8080
+KEYCLOAK_REALM=bahmni
+KEYCLOAK_ADMIN_USER=admin
+KEYCLOAK_ADMIN_PASSWORD=Admin123
+KEYCLOAK_CLIENTS=openmrs,odoo,openelis,bahmni-web
+KEYCLOAK_CLIENT_OPENMRS=openmrs
+KEYCLOAK_CLIENT_ODOO=odoo
+KEYCLOAK_CLIENT_OPENELIS=openelis
+KEYCLOAK_CLIENT_BAHMNI_WEB=bahmni-web
+
 # Host-Port Mappings, credentials for Atomfeed Sync across various services. Defaults to services running in docker.
 OPENMRS_HOST=openmrs
 OPENMRS_PORT=8080

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -37,6 +37,23 @@ services:
     logging: *log-config
     restart: ${RESTART_POLICY}
 
+  keycloak:
+    image: 'quay.io/keycloak/keycloak:${KEYCLOAK_IMAGE_TAG:?}'
+    command: start-dev
+    ports:
+      - '8081:8080'
+    volumes:
+      - keycloak-data:/opt/keycloak/data
+      - '../apps/keycloak:/opt/keycloak/data/import'
+    environment:
+      TZ: ${TZ}
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN_USER:?}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM:?}
+      KEYCLOAK_CLIENTS: ${KEYCLOAK_CLIENTS:?}
+    logging: *log-config
+    restart: ${RESTART_POLICY}
+
   openelis:
     profiles: ["openelis","bahmni-standard"]
     image: 'bahmni/openelis:${OPENELIS_IMAGE_TAG:?[ERROR]}'
@@ -51,6 +68,9 @@ services:
       OPENMRS_ATOMFEED_USER: ${OPENMRS_ATOMFEED_USER:?}
       OPENMRS_ATOMFEED_PASSWORD: ${OPENMRS_ATOMFEED_PASSWORD:?}
       OPENELIS_DB_SERVER: ${OPENELIS_DB_SERVER}
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_OPENELIS}
     depends_on:
       openelisdb:
         condition: service_healthy
@@ -96,6 +116,9 @@ services:
       HOST: ${ODOO_DB_HOST}
       USER: ${ODOO_DB_USER}
       PASSWORD: ${ODOO_DB_PASSWORD}
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ODOO}
     logging: *log-config
     restart: ${RESTART_POLICY}
 
@@ -248,6 +271,9 @@ services:
       OMRS_DB_EXTRA_ARGS: ${OMRS_DB_EXTRA_ARGS}
       LUCENE_MATCH_TYPE: ${LUCENE_MATCH_TYPE}
       DOCUMENT_MAX_SIZE_MB: ${DOCUMENT_MAX_SIZE_MB}
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_OPENMRS}
     #ports:
       # - ${OMRS_DEV_DEBUG_PORT}:${OMRS_DEV_DEBUG_PORT}
     volumes:
@@ -360,6 +386,11 @@ services:
       - "${CONFIG_VOLUME:?}:/usr/local/apache2/htdocs/bahmni_config/:ro"
     #   - "${BAHMNI_APPS_PATH:?}/ui/app/:/usr/local/apache2/htdocs/bahmni"
     #   - "${BAHMNI_APPS_PATH:?}/ui/node_modules/@bower_components/:/usr/local/apache2/htdocs/bahmni/components"
+    environment:
+      TZ: ${TZ}
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_BAHMNI_WEB}
     logging: *log-config
     restart: ${RESTART_POLICY}
 
@@ -613,6 +644,7 @@ volumes:
   odooappdata:
   odoofilestore:
   odooconfig:
+  keycloak-data:
   odoo10dbdata:
   odoo10appdata:
   openmrs-data:


### PR DESCRIPTION
## Summary
- add Keycloak identity provider service to docker-compose
- configure Bahmni services to authenticate via Keycloak
- document Keycloak setup steps

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2058d3e08332bb4513e55938cbc2