### PR TITLE
Add Orthanc PACS service and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Refer this [Wiki Page](https://bahmni.atlassian.net/wiki/spaces/BAH/pages/299630726/Running+Bahmni+on+Docker) for Running Bahmni on Docker for detailed instructions.
 
-## Running Bahmni LITE or STANDARD using docker compose: 
+## Running Bahmni LITE or STANDARD using docker compose:
 1. Navigate to the relevant subfolder for your desired configuration. For example: `cd bahmni-lite`.
 2. Execute the script: `./run-bahmni.sh`. This script provides various options such as start, stop, view logs, pull updates, reset, etc.
 3. Before executing the above commands, ensure that your `.env` file in the sub-folder is correctly configured with the appropriate PROFILE.
@@ -36,3 +36,18 @@ run-bahmni.sh .env.local
 Please choose the appropriate environment variables file based on your requirements and make sure the respective `.env` or `.env-dev` file is properly configured before running the commands.
 
 For detailed instructions and further information, please refer to the [Wiki Page](https://bahmni.atlassian.net/wiki/spaces/BAH/pages/299630726/Running+Bahmni+on+Docker) mentioned above.
+
+## Orthanc PACS Integration
+
+The `bahmni-standard` compose file now includes an [Orthanc](https://www.orthanc-server.com/) service for handling DICOM images. Orthanc exposes the HTTP interface on port `8042` and the DICOM listener on port `4242`. Default credentials are `admin`/`orthanc` and the data is persisted in the `orthanc-data` Docker volume.
+
+The PACS integration container is configured to communicate with Orthanc by default. To customise the connection, update the following environment variables in the `.env` file:
+
+```
+PACS_SERVER_TYPE=ORTHANC
+PACS_SERVER_URL=http://orthanc:8042
+PACS_SERVER_USERNAME=admin
+PACS_SERVER_PASSWORD=orthanc
+```
+
+An example viewer configuration for Bahmni UI is provided at `bahmni-standard/orthanc-viewer-config.json` which points the viewer to the Orthanc web explorer.

--- a/backup_restore/restore_docker_volumes.sh
+++ b/backup_restore/restore_docker_volumes.sh
@@ -56,5 +56,6 @@ copy_from_restore_to_mount /restore-artifacts/uploaded_results /mounts/bahmni-la
 copy_from_restore_to_mount /restore-artifacts/reports /mounts/bahmni-queued-reports
 copy_from_restore_to_mount /restore-artifacts/uploaded-files /mounts/bahmni-uploaded-files
 copy_from_restore_to_mount /restore-artifacts/dcm4chee_archive /mounts/dcm4chee-archive
+copy_from_restore_to_mount /restore-artifacts/orthanc_db /mounts/orthanc-data
 
 log_info -e "File System Restore completed."

--- a/bahmni-standard/backup_bahmni_standard.sh
+++ b/bahmni-standard/backup_bahmni_standard.sh
@@ -30,6 +30,7 @@ pacs_integration_db_backup_file_path=$backup_subfolder_path/pacs_integrationdb_b
 openmrs_service_name="openmrs"
 reports_service_name="reports"
 dcm4chee_service_name="dcm4chee"
+orthanc_service_name="orthanc"
 openmrs_db_service_name="openmrsdb"
 reports_db_service_name="reportsdb"
 openelis_db_service_name="openelisdb"
@@ -87,4 +88,7 @@ backup_container_file_system $odoo_service_name "/var/lib/odoo/filestore" "$BACK
 
 log_info "Taking backup for DCM4CHEE Archive"
 backup_container_file_system $dcm4chee_service_name "/var/lib/bahmni/dcm4chee/server/default/archive/." "$BACKUP_ROOT_FOLDER/dcm4chee_archive"
+
+log_info "Taking backup for Orthanc Storage"
+backup_container_file_system $orthanc_service_name "/var/lib/orthanc/db/." "$BACKUP_ROOT_FOLDER/orthanc_db"
 

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -492,6 +492,21 @@ services:
     logging: *log-config
     restart: ${RESTART_POLICY}
 
+  orthanc:
+    image: orthanc/orthanc-plugins:${ORTHANC_IMAGE_TAG:-latest}
+    profiles: ["pacs","bahmni-standard"]
+    environment:
+      TZ: ${TZ}
+      ORTHANC__REMOTEACCESSALLOWED: "true"
+      ORTHANC__REGISTERED_USERS: '{"admin":"orthanc"}'
+    ports:
+      - '8042:8042'
+      - '4242:4242'
+    volumes:
+      - 'orthanc-data:/var/lib/orthanc/db'
+    logging: *log-config
+    restart: ${RESTART_POLICY}
+
   pacs-integration:
     image: bahmni/pacs-integration:${PACS_INTEGRATION_IMAGE_TAG:?}
     profiles: ["pacs","bahmni-standard"]
@@ -506,6 +521,10 @@ services:
       OPENMRS_PORT: ${OPENMRS_PORT:?}
       OPENMRS_ATOMFEED_USER: ${OPENMRS_ATOMFEED_USER:?}
       OPENMRS_ATOMFEED_PASSWORD: ${OPENMRS_ATOMFEED_PASSWORD:?}
+      PACS_SERVER_TYPE: ORTHANC
+      PACS_SERVER_URL: http://orthanc:8042
+      PACS_SERVER_USERNAME: admin
+      PACS_SERVER_PASSWORD: orthanc
     logging: *log-config
     restart: ${RESTART_POLICY}
 
@@ -533,8 +552,8 @@ services:
     environment:
       TZ: ${TZ}
       PACS_SIMULATOR_TIMEOUT: ${PACS_SIMULATOR_TIMEOUT:?}
-      PACS_SERVER_TYPE: ${PACS_SERVER_TYPE:?}
-      PACS_SERVER_URL: ${PACS_SERVER_URL:?}
+      PACS_SERVER_TYPE: ${PACS_SERVER_TYPE:-ORTHANC}
+      PACS_SERVER_URL: ${PACS_SERVER_URL:-http://orthanc:8042}
       UPDATE_PACS_INTEGRATION_DB: ${UPDATE_PACS_INTEGRATION_DB:?}
       PACS_INTEGRATION_DB_HOST: ${PACS_DB_HOST:?}
       PACS_INTEGRATION_DB_PORT: ${PACS_DB_PORT:?}
@@ -596,6 +615,7 @@ services:
         - 'bahmni-queued-reports:/mounts/bahmni-queued-reports'
         - 'bahmni-uploaded-files:/mounts/bahmni-uploaded-files'
         - 'dcm4chee-archive:/mounts/dcm4chee-archive'
+        - 'orthanc-data:/mounts/orthanc-data'
         - 'configuration_checksums:/mounts/configuration_checksums'
 
   ipd:
@@ -664,3 +684,4 @@ volumes:
   reportsdbdata:
   pacsdbdata:
   dcm4chee-config:
+  orthanc-data:

--- a/bahmni-standard/orthanc-viewer-config.json
+++ b/bahmni-standard/orthanc-viewer-config.json
@@ -1,0 +1,7 @@
+{
+  "pacs": {
+    "enable": true,
+    "restApiUrl": "http://orthanc:8042",
+    "viewerUrl": "http://localhost:8042/app/explorer.html#study?uuid={{studyInstanceUid}}"
+  }
+}


### PR DESCRIPTION
## Summary
- add Orthanc service to standard docker-compose and point PACS integration to it
- include Orthanc data in backup/restore scripts and volumes
- provide sample viewer config and documentation for Orthanc

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: {max: 200}}}' bahmni-standard/docker-compose.yml`
- `jq . bahmni-standard/orthanc-viewer-config.json`
- `shellcheck bahmni-standard/backup_bahmni_standard.sh bahmni-standard/restore_bahmni_standard.sh backup_restore/restore_docker_volumes.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ba215035a48332b89b8ca1d855381c