### PR TITLE
Add multilingual configs and translations

### DIFF
--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -248,8 +248,13 @@ services:
     profiles: ["emr","bahmni-lite","bahmni-mart"]
     volumes:
       - "${CONFIG_VOLUME:?}:/usr/local/apache2/htdocs/bahmni_config/:ro"
+      - "../i18n:/usr/local/apache2/htdocs/i18n:ro"
     #   - "${BAHMNI_APPS_PATH:?}/ui/app/:/usr/local/apache2/htdocs/bahmni"
     #   - "${BAHMNI_APPS_PATH:?}/ui/node_modules/@bower_components/:/usr/local/apache2/htdocs/bahmni/components"
+    environment:
+      TZ: ${TZ}
+      AVAILABLE_LANGUAGES: "en,fa-AF"
+      RTL_LANGUAGES: "fa-AF"
     logging: *log-config
     restart: ${RESTART_POLICY}
 

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -384,6 +384,7 @@ services:
     profiles: ["emr","bahmni-standard","bahmni-mart"]
     volumes:
       - "${CONFIG_VOLUME:?}:/usr/local/apache2/htdocs/bahmni_config/:ro"
+      - "../i18n:/usr/local/apache2/htdocs/i18n:ro"
     #   - "${BAHMNI_APPS_PATH:?}/ui/app/:/usr/local/apache2/htdocs/bahmni"
     #   - "${BAHMNI_APPS_PATH:?}/ui/node_modules/@bower_components/:/usr/local/apache2/htdocs/bahmni/components"
     environment:
@@ -391,6 +392,8 @@ services:
       KEYCLOAK_URL: ${KEYCLOAK_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_BAHMNI_WEB}
+      AVAILABLE_LANGUAGES: "en,fa-AF"
+      RTL_LANGUAGES: "fa-AF"
     logging: *log-config
     restart: ${RESTART_POLICY}
 

--- a/docs/glossary-v0.1.md
+++ b/docs/glossary-v0.1.md
@@ -1,0 +1,6 @@
+# Bahmni Glossary v0.1
+
+- **Bahmni**: Open-source hospital management system built on OpenMRS.
+- **OpenMRS**: Electronic medical record platform forming the core of Bahmni.
+- **Dari**: Persian dialect used in Afghanistan, written right-to-left.
+- **i18n**: Internationalization; making software adaptable to different languages and regions.

--- a/i18n/en/messages.json
+++ b/i18n/en/messages.json
@@ -1,3 +1,5 @@
 {
-  "placeholder": "Add English translations here"
+  "languageSwitcher.label": "Language",
+  "language.en": "English",
+  "language.fa-AF": "Dari"
 }

--- a/i18n/en/registration.json
+++ b/i18n/en/registration.json
@@ -1,0 +1,4 @@
+{
+  "registration.title": "Patient Registration",
+  "registration.search": "Search Patients"
+}

--- a/i18n/en/style.css
+++ b/i18n/en/style.css
@@ -1,0 +1,4 @@
+html[lang="en"] body {
+  direction: ltr;
+  font-family: Arial, sans-serif;
+}

--- a/i18n/fa-AF/messages.json
+++ b/i18n/fa-AF/messages.json
@@ -1,0 +1,5 @@
+{
+  "languageSwitcher.label": "زبان",
+  "language.en": "انگلیسی",
+  "language.fa-AF": "دری"
+}

--- a/i18n/fa-AF/registration.json
+++ b/i18n/fa-AF/registration.json
@@ -1,0 +1,4 @@
+{
+  "registration.title": "ثبت نام بیمار",
+  "registration.search": "جستجوی بیمار"
+}

--- a/i18n/fa-AF/style.css
+++ b/i18n/fa-AF/style.css
@@ -1,0 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic&display=swap');
+
+html[lang="fa-AF"] body {
+  direction: rtl;
+  font-family: 'Noto Naskh Arabic', sans-serif;
+}


### PR DESCRIPTION
## Summary
- add English and Dari translation bundles and styling
- mount i18n resources and expose language switcher in web containers
- document basic glossary terms

## Testing
- `jq . i18n/en/messages.json`
- `jq . i18n/en/registration.json`
- `jq . i18n/fa-AF/messages.json`
- `jq . i18n/fa-AF/registration.json`
- `docker-compose --version` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68ba24b19ed08332b15225ef442136d5