### PR TITLE
feat: add runtime module toggles

### DIFF
--- a/apps/module-toggles.json
+++ b/apps/module-toggles.json
@@ -1,0 +1,6 @@
+{
+  "registration": true,
+  "billing": false,
+  "reports": true,
+  "appointments": true
+}

--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -15,6 +15,9 @@ x-log-config: &log-config
   # update this value to *loki if needed to see logs in grafana dashboard.
   <<: *default
 
+x-module-env: &module-env
+  MODULE_TOGGLES: ${MODULE_TOGGLES}
+
 services:
 
   proxy:
@@ -27,10 +30,13 @@ services:
     logging: *log-config
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
 
   bahmni-config:
     image: 'bahmni/clinic-config:${CONFIG_IMAGE_TAG:?}'
+    environment:
+      <<: *module-env
     volumes:
       - '${CONFIG_VOLUME:?}:/usr/local/bahmni_config'
     logging: *log-config
@@ -42,12 +48,14 @@ services:
     logging: *log-config
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
 
   openmrs:
     profiles: ["emr","bahmni-lite", "bahmni-mart"]
     image: bahmni/openmrs:${OPENMRS_IMAGE_TAG:?}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OMRS_DB_NAME: ${OPENMRS_DB_NAME:?}
       OMRS_DB_HOSTNAME: ${OPENMRS_DB_HOST:?}
@@ -101,6 +109,7 @@ services:
     profiles: ["emr","bahmni-lite", "metabase", "bahmni-mart"]
     command: --character-set-server=utf8 --collation-server=utf8_general_ci
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?}
       MYSQL_DATABASE: ${OPENMRS_DB_NAME:?}
@@ -120,6 +129,7 @@ services:
     volumes:
      - 'crater-app-data:/var/www/storage/app/public'
     environment:
+      <<: *module-env
       TZ: ${TZ}
       APP_URL: ${CRATER_APP_URL:?}
       DB_HOST: ${CRATER_DB_HOST:?}
@@ -144,6 +154,7 @@ services:
     profiles: ["crater","bahmni-lite"]
     restart: unless-stopped
     environment:
+      <<: *module-env
       TZ: ${TZ}
     volumes:
      - 'crater-app-data:/var/www/public/storage'
@@ -160,6 +171,7 @@ services:
       # # and uncomment the line under this one.
       # - ./docker-compose/db/data:/var/lib/mysql:rw,delegated
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MYSQL_USER: ${CRATER_DB_USERNAME:?}
       MYSQL_PASSWORD: ${CRATER_DB_PASSWORD:?}
@@ -172,6 +184,7 @@ services:
     restart: on-failure:[3]
     profiles: ["metabase", "bahmni-mart"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_DB: ${METABASE_DB_NAME:?}
       POSTGRES_USER: ${METABASE_DB_USER:?}
@@ -185,6 +198,7 @@ services:
     restart: on-failure:[3]
     profiles: ["metabase", "bahmni-mart"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MB_ADMIN_EMAIL: ${METABASE_ADMIN_EMAIL:?}
       MB_ADMIN_FIRST_NAME: ${METABASE_ADMIN_FIRST_NAME:?}
@@ -211,6 +225,7 @@ services:
     profiles: ["bahmni-mart"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_DB: ${MART_DB_NAME:?}
       POSTGRES_USER: ${MART_DB_USERNAME:?}
@@ -224,6 +239,7 @@ services:
     profiles: ["bahmni-mart"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       CRON_TIME: ${MART_CRON_TIME:?}
       MART_DB_HOST: ${MART_DB_HOST:?}
@@ -252,6 +268,7 @@ services:
     #   - "${BAHMNI_APPS_PATH:?}/ui/app/:/usr/local/apache2/htdocs/bahmni"
     #   - "${BAHMNI_APPS_PATH:?}/ui/node_modules/@bower_components/:/usr/local/apache2/htdocs/bahmni/components"
     environment:
+      <<: *module-env
       TZ: ${TZ}
       AVAILABLE_LANGUAGES: "en,fa-AF"
       RTL_LANGUAGES: "fa-AF"
@@ -263,6 +280,8 @@ services:
     profiles: ["implementer-interface","emr","bahmni-lite"]
     #volumes:
     #  - "${IMPLEMENTER_INTERFACE_CODE_PATH:?}/dist:/usr/local/apache2/htdocs/implementer-interface"
+    environment:
+      <<: *module-env
     depends_on:
       - openmrs
     logging: *log-config
@@ -272,6 +291,7 @@ services:
     image: bahmni/reports:${REPORTS_IMAGE_TAG:?}
     profiles: ["reports","bahmni-lite","bahmni-mart"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_DB_HOST: ${OPENMRS_DB_HOST:?}
       OPENMRS_DB_NAME: ${OPENMRS_DB_NAME:?}
@@ -300,6 +320,7 @@ services:
     image: ${REPORTS_DB_IMAGE_NAME:?}
     profiles: ["reports","bahmni-lite","bahmni-mart"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?}
       MYSQL_DATABASE: ${REPORTS_DB_NAME:?}
@@ -318,6 +339,7 @@ services:
       - 'bahmni-lab-results:/usr/share/nginx/html/uploaded_results'
       - 'bahmni-uploaded-files:/usr/share/nginx/html/uploaded-files'
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_HOST: ${OPENMRS_HOST:?}
     depends_on:
@@ -337,6 +359,7 @@ services:
     profiles: ["sms"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       SMS_TOKEN: ${SMS_TOKEN}
       SMS_PROVIDER_API: ${SMS_PROVIDER_API}
@@ -352,6 +375,7 @@ services:
     profiles: ["atomfeed-console"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_DB_HOST: ${OPENMRS_DB_HOST}
       OPENMRS_DB_NAME: ${OPENMRS_DB_NAME}
@@ -363,6 +387,7 @@ services:
     profiles: ["crater","bahmni-lite"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_HOST: ${OPENMRS_HOST:?}
       OPENMRS_PORT: ${OPENMRS_PORT:?}
@@ -383,6 +408,7 @@ services:
     profiles: ["crater","bahmni-lite"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${CRATER_ATOMFEED_DB_NAME:?}
@@ -393,6 +419,8 @@ services:
     image: bash:5.2.15
     profiles: ["restore"]
     command: "bash /restore_docker_volumes.sh"
+    environment:
+      <<: *module-env
     volumes:
         - "${RESTORE_ARTIFACTS_PATH}:/restore-artifacts"
         - '../backup_restore/restore_docker_volumes.sh:/restore_docker_volumes.sh'
@@ -408,6 +436,7 @@ services:
     profiles: [ "cdss" ]
     image: bahmni/cdss-reference:${CDSS_IMAGE_TAG:?}
     environment:
+      <<: *module-env
       JAVA_OPTS: ${CDSS_JAVA_SERVER_OPTS}
     logging: *log-config
 
@@ -415,6 +444,7 @@ services:
     profiles: [ "snowstorm-lite" ]
     image: snomedinternational/snowstorm-lite:${SNOWSTORM_LITE_IMAGE_TAG:?}
     environment:
+      <<: *module-env
       JDK_JAVA_OPTIONS: ${SNOWSTORM_LITE_JAVA_SERVER_OPTS}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/fhir/CodeSystem"]
@@ -428,6 +458,7 @@ services:
     image: alpine
     command: "sh /load-snowstorm-data.sh"
     environment:
+      <<: *module-env
       SNOWSTORM_LITE_ADMIN_PASSWORD: ${SNOWSTORM_LITE_ADMIN_PASSWORD:?}
     logging: *log-config
     volumes:

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -15,6 +15,9 @@ x-log-config: &log-config
   # update this value to *loki if needed to see logs in grafana dashboard.
   <<: *default
 
+x-module-env: &module-env
+  MODULE_TOGGLES: ${MODULE_TOGGLES}
+
 
 services:
 
@@ -28,10 +31,13 @@ services:
     logging: *log-config
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
 
   bahmni-config:
     image: 'bahmni/standard-config:${CONFIG_IMAGE_TAG:?}'
+    environment:
+      <<: *module-env
     volumes:
       - '${CONFIG_VOLUME:?}:/usr/local/bahmni_config'
     logging: *log-config
@@ -46,6 +52,7 @@ services:
       - keycloak-data:/opt/keycloak/data
       - '../apps/keycloak:/opt/keycloak/data/import'
     environment:
+      <<: *module-env
       TZ: ${TZ}
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN_USER:?}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?}
@@ -62,6 +69,7 @@ services:
       - "bahmni-lab-results:/home/bahmni/uploaded_results"
       - "bahmni-uploaded-files:/home/bahmni/uploaded-files"
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_HOST: ${OPENMRS_HOST}
       OPENMRS_PORT: ${OPENMRS_PORT:?}
@@ -89,6 +97,7 @@ services:
       timeout: 5s
       retries: 5
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_USER: ${OPENELIS_DB_USER:?}
       POSTGRES_PASSWORD: ${OPENELIS_DB_PASSWORD:?}
@@ -112,6 +121,7 @@ services:
       odoodb:
         condition: service_healthy
     environment:
+      <<: *module-env
       TZ: ${TZ}
       HOST: ${ODOO_DB_HOST}
       USER: ${ODOO_DB_USER}
@@ -134,6 +144,7 @@ services:
       timeout: 5s
       retries: 10
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_DB: ${ODOO_DB_NAME:?}
       POSTGRES_PASSWORD: ${ODOO_DB_PASSWORD}
@@ -145,6 +156,7 @@ services:
     profiles: ["odoo","bahmni-standard"]
     image: 'bahmni/odoo-connect:${ODOO_CONNECT_IMAGE_TAG:?[ERROR]}'
     environment:
+      <<: *module-env
       TZ: ${TZ}
       IS_ODOO_16: true
       ODOO_DB_SERVER: ${ODOO_DB_HOST}
@@ -183,6 +195,7 @@ services:
       odoo-10-db:
         condition: service_healthy
     environment:
+      <<: *module-env
       TZ: ${TZ}
       HOST: ${ODOO_10_DB_HOST}
       USER: ${ODOO_10_DB_USER}
@@ -201,6 +214,7 @@ services:
       interval: 10s
       timeout: 5s
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_DB: ${ODOO_10_DB_NAME:?}
       POSTGRES_PASSWORD: ${ODOO_10_DB_PASSWORD}
@@ -212,6 +226,7 @@ services:
     profiles: ["odoo-10"]
     image: 'bahmni/odoo-connect:${ODOO_CONNECT_IMAGE_TAG:?[ERROR]}'
     environment:
+      <<: *module-env
       TZ: ${TZ}
       ODOO_DB_SERVER: odoo-10-db
       ODOO_DB_USERNAME: ${ODOO_10_DB_USER:?}
@@ -238,6 +253,7 @@ services:
     profiles: ["emr","bahmni-standard", "bahmni-mart"]
     image: bahmni/openmrs:${OPENMRS_IMAGE_TAG:?}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OMRS_DB_NAME: ${OPENMRS_DB_NAME:?}
       OMRS_DB_HOSTNAME: ${OPENMRS_DB_HOST:?}
@@ -297,6 +313,7 @@ services:
     profiles: ["emr","bahmni-standard", "metabase", "bahmni-mart"]
     command: "--sql-mode=${OPENMRS_DB_SQL_MODES:?}"
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?}
       MYSQL_DATABASE: ${OPENMRS_DB_NAME:?}
@@ -312,6 +329,7 @@ services:
     restart: on-failure:[3]
     profiles: ["metabase", "bahmni-mart"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_DB: ${METABASE_DB_NAME:?}
       POSTGRES_USER: ${METABASE_DB_USER:?}
@@ -324,6 +342,7 @@ services:
     restart: on-failure:[3]
     profiles: ["metabase", "bahmni-mart"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MB_ADMIN_EMAIL: ${METABASE_ADMIN_EMAIL:?}
       MB_ADMIN_FIRST_NAME: ${METABASE_ADMIN_FIRST_NAME:?}
@@ -350,6 +369,7 @@ services:
     profiles: ["bahmni-mart"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_DB: ${MART_DB_NAME:?}
       POSTGRES_USER: ${MART_DB_USERNAME:?}
@@ -362,6 +382,7 @@ services:
     profiles: ["bahmni-mart"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       CRON_TIME: ${MART_CRON_TIME:?}
       MART_DB_HOST: ${MART_DB_HOST:?}
@@ -388,6 +409,7 @@ services:
     #   - "${BAHMNI_APPS_PATH:?}/ui/app/:/usr/local/apache2/htdocs/bahmni"
     #   - "${BAHMNI_APPS_PATH:?}/ui/node_modules/@bower_components/:/usr/local/apache2/htdocs/bahmni/components"
     environment:
+      <<: *module-env
       TZ: ${TZ}
       KEYCLOAK_URL: ${KEYCLOAK_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}
@@ -402,6 +424,8 @@ services:
     profiles: ["implementer-interface","emr","bahmni-standard"]
     #volumes:
     #  - "${IMPLEMENTER_INTERFACE_CODE_PATH:?}/dist:/usr/local/apache2/htdocs/implementer_interface"
+    environment:
+      <<: *module-env
     depends_on:
       - openmrs
     logging: *log-config
@@ -411,6 +435,7 @@ services:
     image: bahmni/reports:${REPORTS_IMAGE_TAG:?}
     profiles: ["reports","bahmni-standard"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_DB_HOST: ${OPENMRS_DB_HOST:?}
       OPENMRS_DB_NAME: ${OPENMRS_DB_NAME:?}
@@ -444,6 +469,7 @@ services:
     image: ${REPORTS_DB_IMAGE_NAME:?}
     profiles: ["reports","bahmni-standard"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?}
       MYSQL_DATABASE: ${REPORTS_DB_NAME:?}
@@ -462,6 +488,7 @@ services:
       - 'bahmni-lab-results:/usr/share/nginx/html/uploaded_results'
       - "bahmni-uploaded-files:/usr/share/nginx/html/uploaded-files"
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_HOST: ${OPENMRS_HOST:?}
     depends_on:
@@ -473,6 +500,8 @@ services:
     image: bahmni/appointments:${APPOINTMENTS_IMAGE_TAG:?}
     profiles: ["emr","bahmni-standard"]
     restart: ${RESTART_POLICY}
+    environment:
+      <<: *module-env
     # volumes:
     # - "${APPOINTMENTS_PATH:?}/dist/:/usr/local/apache2/htdocs/appointments"
 
@@ -480,6 +509,7 @@ services:
     image: bahmni/dcm4chee:${DCM4CHEE_IMAGE_TAG:?}
     profiles: ["pacs","bahmni-standard"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       DB_HOST: ${PACS_DB_HOST:?}
       DB_PORT: ${PACS_DB_PORT:?}
@@ -499,6 +529,7 @@ services:
     image: orthanc/orthanc-plugins:${ORTHANC_IMAGE_TAG:-latest}
     profiles: ["pacs","bahmni-standard"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       ORTHANC__REMOTEACCESSALLOWED: "true"
       ORTHANC__REGISTERED_USERS: '{"admin":"orthanc"}'
@@ -514,6 +545,7 @@ services:
     image: bahmni/pacs-integration:${PACS_INTEGRATION_IMAGE_TAG:?}
     profiles: ["pacs","bahmni-standard"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       DB_HOST: ${PACS_DB_HOST:?}
       DB_PORT: ${PACS_DB_PORT:?}
@@ -535,6 +567,7 @@ services:
     image: postgres:9.6
     profiles: ["pacs","bahmni-standard"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       POSTGRES_PASSWORD: ${PACS_DB_ROOT_PASSWORD}
       DCM4CHEE_DB_NAME: ${DCM4CHEE_DB_NAME:?}
@@ -553,6 +586,7 @@ services:
     image: bahmni/pacs-simulator:${PACS_SIMULATOR_IMAGE_TAG:?}
     profiles: ["pacs-simulator"]
     environment:
+      <<: *module-env
       TZ: ${TZ}
       PACS_SIMULATOR_TIMEOUT: ${PACS_SIMULATOR_TIMEOUT:?}
       PACS_SERVER_TYPE: ${PACS_SERVER_TYPE:-ORTHANC}
@@ -572,6 +606,7 @@ services:
     profiles: ["atomfeed-console"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       OPENMRS_DB_HOST: ${OPENMRS_DB_HOST}
       OPENMRS_DB_NAME: ${OPENMRS_DB_NAME}
@@ -594,6 +629,7 @@ services:
     profiles: ["sms"]
     restart: ${RESTART_POLICY}
     environment:
+      <<: *module-env
       TZ: ${TZ}
       SMS_TOKEN: ${SMS_TOKEN}
       SMS_ORIGINATOR: ${SMS_ORIGINATOR}
@@ -608,6 +644,8 @@ services:
     image: bash:5.2.15
     profiles: ["restore"]
     command: "bash /restore_docker_volumes.sh"
+    environment:
+      <<: *module-env
     volumes:
         - "${RESTORE_ARTIFACTS_PATH}:/restore-artifacts"
         - '../backup_restore/restore_docker_volumes.sh:/restore_docker_volumes.sh'
@@ -628,12 +666,15 @@ services:
     restart: ${RESTART_POLICY}
     # volumes:
     #   - "${IPD_PATH:?}/dist/federation/:/usr/local/apache2/htdocs/ipd"
+    environment:
+      <<: *module-env
     logging: *log-config
 
   cdss:
     profiles: [ "cdss" ]
     image: bahmni/cdss-reference:${CDSS_IMAGE_TAG:?}
     environment:
+      <<: *module-env
       JAVA_OPTS: ${CDSS_JAVA_SERVER_OPTS}
     logging: *log-config
 
@@ -641,6 +682,7 @@ services:
     profiles: [ "snowstorm-lite" ]
     image: snomedinternational/snowstorm-lite:${SNOWSTORM_LITE_IMAGE_TAG:?}
     environment:
+      <<: *module-env
       JDK_JAVA_OPTIONS: ${SNOWSTORM_LITE_JAVA_SERVER_OPTS}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/fhir/CodeSystem"]
@@ -654,6 +696,7 @@ services:
     image: alpine
     command: "sh /load-snowstorm-data.sh"
     environment:
+      <<: *module-env
       SNOWSTORM_LITE_ADMIN_PASSWORD: ${SNOWSTORM_LITE_ADMIN_PASSWORD:?}
     logging: *log-config
     volumes:

--- a/docs/module-toggles.md
+++ b/docs/module-toggles.md
@@ -1,0 +1,32 @@
+# Module Toggles
+
+Bahmni Docker allows features to be enabled or disabled at runtime.
+The configuration lives in `/apps/module-toggles.json` and is loaded
+when `run-bahmni.sh` starts the stack.
+
+```json
+{
+  "registration": true,
+  "billing": false,
+  "reports": true,
+  "appointments": true
+}
+```
+
+Each key represents a supported module and the boolean value indicates
+whether the module is enabled by default.
+
+The `run-bahmni.sh` script reads this file and exposes the content to
+all containers using the `MODULE_TOGGLES` environment variable.  Bahmni
+services should inspect this variable on startup and hide their routes
+or UI elements when a module is disabled.
+
+To override a module's state, edit `apps/module-toggles.json` and
+restart Bahmni:
+
+```bash
+cd bahmni-lite   # or bahmni-standard
+./run-bahmni.sh
+```
+
+The stack will restart using the updated module configuration.

--- a/run-bahmni.sh
+++ b/run-bahmni.sh
@@ -47,6 +47,7 @@ function checkIfDirectoryIsCorrect {
 function start {
     echo "Executing command: 'docker compose up -d' with the images specified in the $file file"
     echo "Starting Bahmni with default profile from $file file"
+    echo "Module toggles: ${MODULE_TOGGLES}"
     docker compose --env-file "$file" up -d
 }
 
@@ -181,6 +182,14 @@ function shutdown {
 checkDockerAndDockerComposeVersion
 # Check Directory is correct
 checkIfDirectoryIsCorrect
+
+# Load module toggles configuration so docker compose can pass it to services
+MODULE_TOGGLES_FILE="../apps/module-toggles.json"
+if [ -f "$MODULE_TOGGLES_FILE" ]; then
+    export MODULE_TOGGLES=$(jq -c '.' "$MODULE_TOGGLES_FILE")
+else
+    echo "Warning: module toggles file not found at $MODULE_TOGGLES_FILE" >&2
+fi
 
 echo "Please select an option:"
 echo "------------------------"


### PR DESCRIPTION
## Summary
- add module toggles configuration and propagate to all services
- expose toggles via run-bahmni startup script
- document how to manage module toggles

## Testing
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ba26f2e3f88332a978ed3bcf12bd89